### PR TITLE
Feat: Create add button(success) and delete button(didn't work)

### DIFF
--- a/.idea/studiobot.xml
+++ b/.idea/studiobot.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="StudioBotProjectSettings">
+    <option name="shareContext" value="OptedIn" />
+  </component>
+</project>

--- a/app/src/main/java/com/example/emergencyguide/EmergencyNumber/EmergencyNumberActivity.kt
+++ b/app/src/main/java/com/example/emergencyguide/EmergencyNumber/EmergencyNumberActivity.kt
@@ -22,8 +22,10 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.*
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.ArrowBack
 import androidx.compose.material.icons.filled.Call
+import androidx.compose.material.icons.filled.Edit
 import androidx.compose.material.icons.filled.LocalFireDepartment
 import androidx.compose.material.icons.filled.LocalHospital
 import androidx.compose.material.icons.filled.LocalPolice
@@ -105,6 +107,7 @@ class EmergencyNumberActivity : AppCompatActivity() {
                         EmergencyContact(Icons.Default.Waves, "122", "해양사고")
                     }
                     1 -> {
+                        AddandEditButtons()
                         EmergencyContact(Icons.Default.LooksOne, "010-1111-1111", "비긴급 1번")
                         EmergencyContact(Icons.Default.LooksTwo, "010-2222-2222", "비긴급 2번")
                         EmergencyContact(Icons.Default.Looks3, "010-3333-3333", "비긴급 3번")
@@ -144,4 +147,23 @@ class EmergencyNumberActivity : AppCompatActivity() {
             Divider(color = Color.Gray, thickness = 1.dp, modifier = Modifier.align(Alignment.BottomCenter))
         }
     }
+
+    @Composable
+    fun AddandEditButtons() {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                ,
+            horizontalArrangement = Arrangement.End,
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            IconButton(onClick = { /* TODO: Add action */ }) {
+                Icon(imageVector = Icons.Default.Add, contentDescription = "Add")
+            }
+            IconButton(onClick = { /* TODO: Edit action */ }) {
+                Icon(imageVector = Icons.Default.Edit, contentDescription = "Edit")
+            }
+        }
+    }
+
 }

--- a/app/src/main/java/com/example/emergencyguide/EmergencyNumber/EmergencyNumberActivity.kt
+++ b/app/src/main/java/com/example/emergencyguide/EmergencyNumber/EmergencyNumberActivity.kt
@@ -53,7 +53,7 @@ import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.input.TextFieldValue
 import androidx.compose.ui.text.input.VisualTransformation
 import androidx.compose.ui.unit.dp
-import com.example.emergencyguide.EmergencyNumber.composables.AddandEditButtons
+import com.example.emergencyguide.EmergencyNumber.composables.AddandDeleteButtons
 import com.example.emergencyguide.EmergencyNumber.composables.CreatePersonalDialog
 import com.example.emergencyguide.EmergencyNumber.composables.EmergencyContact
 
@@ -132,7 +132,7 @@ class EmergencyNumberActivity : AppCompatActivity() {
                     }
                     1 -> {
 
-                        AddandEditButtons(onAddClick = { isDialogOpen.value = true })
+                        AddandDeleteButtons(onAddClick = { isDialogOpen.value = true })
                         contacts.forEach { (number, description) ->
                             EmergencyContact(Icons.Default.AccountBox, number, description)
                         }

--- a/app/src/main/java/com/example/emergencyguide/EmergencyNumber/EmergencyNumberActivity.kt
+++ b/app/src/main/java/com/example/emergencyguide/EmergencyNumber/EmergencyNumberActivity.kt
@@ -37,6 +37,7 @@ import androidx.compose.material.icons.filled.Looks4
 import androidx.compose.material.icons.filled.LooksOne
 import androidx.compose.material.icons.filled.LooksTwo
 import androidx.compose.material.icons.filled.Waves
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.MutableState
 import androidx.compose.runtime.mutableStateListOf
 import androidx.compose.runtime.mutableStateOf
@@ -78,69 +79,87 @@ class EmergencyNumberActivity : AppCompatActivity() {
         val selectedTabIndex = remember { mutableStateOf(0) }
 
         val isDialogOpen = remember { mutableStateOf(false) }
-        val contacts = remember { mutableStateListOf<Pair<String, String>>() }
+
+        // 수정 중인지 여부
+        val isEditing = remember { mutableStateOf(false) }
+
+
+        // 연락처
+        val contacts = remember { mutableStateListOf<Triple<String, String, Boolean>>() }
 
 
 
-        CreatePersonalDialog(isDialogOpen) { number, description ->
-            contacts.add(number to description)
+        // isSelected가 true인 연락처들을 contacts에서 제거하는 함수
+        fun handleDeleteCompleteClick() {
+            contacts.removeAll { it.third }
+            isEditing.value = false
         }
 
-        Surface(
-            modifier = Modifier.fillMaxSize(),
-            color = Color.White
-        ) {
-            Column(
-                modifier = Modifier
-                    .fillMaxSize()
-                    .padding(16.dp),
+
+        CreatePersonalDialog(isDialogOpen) { number, description, isSelected ->
+            contacts.add(Triple(number, description, isSelected))
+        }
+
+
+            Surface(
+                modifier = Modifier.fillMaxSize(),
+                color = Color.White
             ) {
-                TopAppBar(
-                    title = { Text(text = "긴급 연락처") },
-                    navigationIcon = {
-                        IconButton(onClick = { finish() }) {
-                            Icon(imageVector = Icons.Default.ArrowBack, contentDescription = "Back")
-                        }
-                    },
-                    backgroundColor = Color.White,
-                    contentColor = Color.Black,
-                    elevation = 0.dp
-                )
+                Column(
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .padding(16.dp),
+                ) {
+                    TopAppBar(
+                        title = { Text(text = "긴급 연락처") },
+                        navigationIcon = {
+                            IconButton(onClick = { finish() }) {
+                                Icon(imageVector = Icons.Default.ArrowBack, contentDescription = "Back")
+                            }
+                        },
+                        backgroundColor = Color.White,
+                        contentColor = Color.Black,
+                        elevation = 0.dp
+                    )
 
-                Row(Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.Start) { // 왼쪽 정렬
-                    TabRow(
-                        selectedTabIndex = selectedTabIndex.value,
-                        backgroundColor = Color.Transparent, // 배경 투명하게
-                        contentColor = Color.Black // 글자 검은색으로
-                    ) {
-                        tabsList.forEachIndexed { index, title ->
-                            Tab(
-                                text = { Text(title) },
-                                selected = selectedTabIndex.value == index,
-                                onClick = { selectedTabIndex.value = index }
+                    Row(Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.Start) { // 왼쪽 정렬
+                        TabRow(
+                            selectedTabIndex = selectedTabIndex.value,
+                            backgroundColor = Color.Transparent, // 배경 투명하게
+                            contentColor = Color.Black // 글자 검은색으로
+                        ) {
+                            tabsList.forEachIndexed { index, title ->
+                                Tab(
+                                    text = { Text(title) },
+                                    selected = selectedTabIndex.value == index,
+                                    onClick = { selectedTabIndex.value = index }
+                                )
+                            }
+                        }
+                    }
+
+                    when (selectedTabIndex.value) {
+                        0 -> {
+                            EmergencyContact(Icons.Default.LocalFireDepartment, "119", "화재", isEditing)
+                            EmergencyContact(Icons.Default.LocalHospital, "119", "응급실", isEditing)
+                            EmergencyContact(Icons.Default.LocalPolice, "112", "경찰", isEditing)
+                            EmergencyContact(Icons.Default.Waves, "122", "해양사고", isEditing)
+                        }
+                        1 -> {
+
+                            AddandDeleteButtons(
+                                onAddClick = { isDialogOpen.value = true },
+                                onDeleteClick = { isEditing.value = true },
+                                onDeleteCompleteClick = { handleDeleteCompleteClick() },
+                                isEditing = isEditing
                             )
+                            contacts.forEach { (number, description) ->
+                                EmergencyContact(Icons.Default.AccountBox, number, description, isEditing)
+                            }
+
                         }
-                    }
-                }
-
-                when (selectedTabIndex.value) {
-                    0 -> {
-                        EmergencyContact(Icons.Default.LocalFireDepartment, "119", "화재")
-                        EmergencyContact(Icons.Default.LocalHospital, "119", "응급실")
-                        EmergencyContact(Icons.Default.LocalPolice, "112", "경찰")
-                        EmergencyContact(Icons.Default.Waves, "122", "해양사고")
-                    }
-                    1 -> {
-
-                        AddandDeleteButtons(onAddClick = { isDialogOpen.value = true })
-                        contacts.forEach { (number, description) ->
-                            EmergencyContact(Icons.Default.AccountBox, number, description)
-                        }
-
                     }
                 }
             }
         }
-    }
-
 }

--- a/app/src/main/java/com/example/emergencyguide/EmergencyNumber/EmergencyNumberActivity.kt
+++ b/app/src/main/java/com/example/emergencyguide/EmergencyNumber/EmergencyNumberActivity.kt
@@ -20,8 +20,11 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.KeyboardActions
+import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material.*
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.AccountBox
 import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.ArrowBack
 import androidx.compose.material.icons.filled.Call
@@ -34,17 +37,29 @@ import androidx.compose.material.icons.filled.Looks4
 import androidx.compose.material.icons.filled.LooksOne
 import androidx.compose.material.icons.filled.LooksTwo
 import androidx.compose.material.icons.filled.Waves
+import androidx.compose.runtime.MutableState
+import androidx.compose.runtime.mutableStateListOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.FocusDirection
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.TextRange
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.text.input.TextFieldValue
+import androidx.compose.ui.text.input.VisualTransformation
 import androidx.compose.ui.unit.dp
+import com.example.emergencyguide.EmergencyNumber.composables.AddandEditButtons
+import com.example.emergencyguide.EmergencyNumber.composables.CreatePersonalDialog
+import com.example.emergencyguide.EmergencyNumber.composables.EmergencyContact
 
 class EmergencyNumberActivity : AppCompatActivity() {
     private lateinit var binding: ActivityEmergencyNumberBinding
-    private val tabsList = listOf("긴급", "비긴급")
+    private val tabsList = listOf("국가", "개인")
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -61,6 +76,15 @@ class EmergencyNumberActivity : AppCompatActivity() {
     @Composable
     private fun InitComposeContent() {
         val selectedTabIndex = remember { mutableStateOf(0) }
+
+        val isDialogOpen = remember { mutableStateOf(false) }
+        val contacts = remember { mutableStateListOf<Pair<String, String>>() }
+
+
+
+        CreatePersonalDialog(isDialogOpen) { number, description ->
+            contacts.add(number to description)
+        }
 
         Surface(
             modifier = Modifier.fillMaxSize(),
@@ -107,61 +131,14 @@ class EmergencyNumberActivity : AppCompatActivity() {
                         EmergencyContact(Icons.Default.Waves, "122", "해양사고")
                     }
                     1 -> {
-                        AddandEditButtons()
-                        EmergencyContact(Icons.Default.LooksOne, "010-1111-1111", "비긴급 1번")
-                        EmergencyContact(Icons.Default.LooksTwo, "010-2222-2222", "비긴급 2번")
-                        EmergencyContact(Icons.Default.Looks3, "010-3333-3333", "비긴급 3번")
-                        EmergencyContact(Icons.Default.Looks4, "010-4444-4444", "비긴급 4번")
+
+                        AddandEditButtons(onAddClick = { isDialogOpen.value = true })
+                        contacts.forEach { (number, description) ->
+                            EmergencyContact(Icons.Default.AccountBox, number, description)
+                        }
+
                     }
                 }
-            }
-        }
-    }
-
-
-    @Composable
-    fun EmergencyContact(icon: androidx.compose.ui.graphics.vector.ImageVector, number: String, title: String) {
-        Box(
-            modifier = Modifier
-                .fillMaxWidth()
-                .height(100.dp)
-                .padding(vertical = 8.dp),
-        ) {
-            Row(
-                modifier = Modifier
-                    .fillMaxSize(),
-                verticalAlignment = Alignment.CenterVertically
-            ) {
-                Icon(imageVector = icon, contentDescription = title, modifier = Modifier.size(24.dp))
-                Spacer(modifier = Modifier.width(16.dp))
-                Column(
-                    modifier = Modifier.weight(1f)
-                ) {
-                    Text(text = number, style = MaterialTheme.typography.h6, fontWeight = FontWeight.Bold)
-                    Text(text = title)
-                }
-                IconButton(onClick = { /* call action 적기 */ }) {
-                    Icon(imageVector = Icons.Default.Call, contentDescription = "Call")
-                }
-            }
-            Divider(color = Color.Gray, thickness = 1.dp, modifier = Modifier.align(Alignment.BottomCenter))
-        }
-    }
-
-    @Composable
-    fun AddandEditButtons() {
-        Row(
-            modifier = Modifier
-                .fillMaxWidth()
-                ,
-            horizontalArrangement = Arrangement.End,
-            verticalAlignment = Alignment.CenterVertically
-        ) {
-            IconButton(onClick = { /* TODO: Add action */ }) {
-                Icon(imageVector = Icons.Default.Add, contentDescription = "Add")
-            }
-            IconButton(onClick = { /* TODO: Edit action */ }) {
-                Icon(imageVector = Icons.Default.Edit, contentDescription = "Edit")
             }
         }
     }

--- a/app/src/main/java/com/example/emergencyguide/EmergencyNumber/composables/AddandDeleteButtons.kt
+++ b/app/src/main/java/com/example/emergencyguide/EmergencyNumber/composables/AddandDeleteButtons.kt
@@ -7,13 +7,14 @@ import androidx.compose.material.Icon
 import androidx.compose.material.IconButton
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Add
+import androidx.compose.material.icons.filled.Delete
 import androidx.compose.material.icons.filled.Edit
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 
 @Composable
-fun AddandEditButtons(onAddClick: () -> Unit) {
+fun AddandDeleteButtons(onAddClick: () -> Unit) {
     Row(
         modifier = Modifier
             .fillMaxWidth(),
@@ -23,8 +24,8 @@ fun AddandEditButtons(onAddClick: () -> Unit) {
         IconButton(onClick = onAddClick) {
             Icon(imageVector = Icons.Default.Add, contentDescription = "Add")
         }
-        IconButton(onClick = { /* TODO: Edit action */ }) {
-            Icon(imageVector = Icons.Default.Edit, contentDescription = "Edit")
+        IconButton(onClick = { /* TODO: Delete action */ }) {
+            Icon(imageVector = Icons.Default.Delete, contentDescription = "Delete")
         }
     }
 }

--- a/app/src/main/java/com/example/emergencyguide/EmergencyNumber/composables/AddandDeleteButtons.kt
+++ b/app/src/main/java/com/example/emergencyguide/EmergencyNumber/composables/AddandDeleteButtons.kt
@@ -8,24 +8,39 @@ import androidx.compose.material.IconButton
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.Delete
-import androidx.compose.material.icons.filled.Edit
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.MutableState
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 
 @Composable
-fun AddandDeleteButtons(onAddClick: () -> Unit) {
+fun AddandDeleteButtons(onAddClick: () -> Unit,
+                        onDeleteClick: () -> Unit,
+                        onDeleteCompleteClick: () -> Unit,
+                        isEditing: MutableState<Boolean>) {
     Row(
         modifier = Modifier
             .fillMaxWidth(),
         horizontalArrangement = Arrangement.End,
         verticalAlignment = Alignment.CenterVertically
     ) {
-        IconButton(onClick = onAddClick) {
-            Icon(imageVector = Icons.Default.Add, contentDescription = "Add")
+
+        // 수정 중일 때(삭제 버튼만)
+        if (isEditing.value) {
+            IconButton(onClick = onDeleteCompleteClick) {
+                Icon(imageVector = Icons.Default.Delete, contentDescription = "Delete")
+            }
         }
-        IconButton(onClick = { /* TODO: Delete action */ }) {
-            Icon(imageVector = Icons.Default.Delete, contentDescription = "Delete")
+
+        // 수정 중이 아닐 때
+        else {
+            IconButton(onClick = onAddClick) {
+                Icon(imageVector = Icons.Default.Add, contentDescription = "Add")
+            }
+            IconButton(onClick = onDeleteClick) {
+                Icon(imageVector = Icons.Default.Delete, contentDescription = "Delete")
+            }
         }
+
     }
 }

--- a/app/src/main/java/com/example/emergencyguide/EmergencyNumber/composables/AddandEditButtons.kt
+++ b/app/src/main/java/com/example/emergencyguide/EmergencyNumber/composables/AddandEditButtons.kt
@@ -1,0 +1,30 @@
+package com.example.emergencyguide.EmergencyNumber.composables
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.material.Icon
+import androidx.compose.material.IconButton
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Add
+import androidx.compose.material.icons.filled.Edit
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+
+@Composable
+fun AddandEditButtons(onAddClick: () -> Unit) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth(),
+        horizontalArrangement = Arrangement.End,
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        IconButton(onClick = onAddClick) {
+            Icon(imageVector = Icons.Default.Add, contentDescription = "Add")
+        }
+        IconButton(onClick = { /* TODO: Edit action */ }) {
+            Icon(imageVector = Icons.Default.Edit, contentDescription = "Edit")
+        }
+    }
+}

--- a/app/src/main/java/com/example/emergencyguide/EmergencyNumber/composables/CreatePersonalDialog.kt
+++ b/app/src/main/java/com/example/emergencyguide/EmergencyNumber/composables/CreatePersonalDialog.kt
@@ -1,0 +1,107 @@
+package com.example.emergencyguide.EmergencyNumber.composables
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.material.AlertDialog
+import androidx.compose.material.Button
+import androidx.compose.material.ButtonDefaults
+import androidx.compose.material.MaterialTheme
+import androidx.compose.material.Text
+import androidx.compose.material.TextField
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.MutableState
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.input.ImeAction
+import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.text.input.VisualTransformation
+import androidx.compose.ui.unit.dp
+
+@Composable
+fun CreatePersonalDialog(isDialogOpen: MutableState<Boolean>, onAddContact: (String, String) -> Unit) {
+    val focusRequester = remember { FocusRequester() }
+    val errorState = remember { mutableStateOf("") }
+
+    if (isDialogOpen.value) {
+        AlertDialog(
+            onDismissRequest = { isDialogOpen.value = false },
+            text = {
+                Column(
+                    modifier = Modifier.padding(8.dp)
+                ) {
+
+                    Text(
+                        fontSize = MaterialTheme.typography.h5.fontSize,
+                        color = Color.Black,
+                        text = "전화번호 추가"
+                    )
+
+                    Spacer(modifier = Modifier.height(32.dp))
+
+                    val number = remember { mutableStateOf("") }
+                    val description = remember { mutableStateOf("") }
+
+                    TextField(
+                        value = number.value,
+                        onValueChange = { newValue ->
+                            // 숫자만 허용하고 빈칸 입력을 허용하지 않음
+                            if (newValue.all { it.isDigit() } && newValue.isNotBlank()) {
+                                number.value = newValue
+                            }
+                        },
+                        visualTransformation = VisualTransformation.None,
+                        label = { Text("전화번호") },
+                        modifier = Modifier.padding(bottom = 8.dp),
+                        keyboardOptions = KeyboardOptions(imeAction = ImeAction.Next, keyboardType = KeyboardType.Number),
+                    )
+                    TextField(
+                        value = description.value,
+                        onValueChange = { newValue ->
+                            // 빈칸 입력을 허용하지 않음
+                            if (newValue.isNotBlank()) {
+                                description.value = newValue
+                            }
+                        },
+                        label = { Text("설명") },
+                        modifier = Modifier.padding(bottom = 8.dp)
+                    )
+
+                    // 오류 메시지 표시
+                    if (errorState.value.isNotBlank()) {
+                        Text(color = Color.Red, text = errorState.value)
+                    }
+
+                    Row(
+                        modifier = Modifier.fillMaxWidth(),
+                        horizontalArrangement = Arrangement.End
+                    ) {
+                        Button(
+                            onClick = {
+                                if (number.value.isBlank() || description.value.isBlank()) {
+                                    errorState.value = "전화번호나 설명을 입력해주세요."
+                                } else {
+                                    onAddContact(number.value, description.value)
+                                    isDialogOpen.value = false
+                                    errorState.value = ""
+                                }
+                            },
+                            colors = ButtonDefaults.buttonColors(backgroundColor = Color.Black)
+                        ) {
+                            Text("추가하기", color = Color.White)
+                        }
+                    }
+                }
+            },
+            confirmButton = { }
+        )
+    }
+}

--- a/app/src/main/java/com/example/emergencyguide/EmergencyNumber/composables/CreatePersonalDialog.kt
+++ b/app/src/main/java/com/example/emergencyguide/EmergencyNumber/composables/CreatePersonalDialog.kt
@@ -27,8 +27,7 @@ import androidx.compose.ui.text.input.VisualTransformation
 import androidx.compose.ui.unit.dp
 
 @Composable
-fun CreatePersonalDialog(isDialogOpen: MutableState<Boolean>, onAddContact: (String, String) -> Unit) {
-    val focusRequester = remember { FocusRequester() }
+fun CreatePersonalDialog(isDialogOpen: MutableState<Boolean>, onAddContact: (String, String, Boolean) -> Unit) {
     val errorState = remember { mutableStateOf("") }
 
     if (isDialogOpen.value) {
@@ -89,7 +88,7 @@ fun CreatePersonalDialog(isDialogOpen: MutableState<Boolean>, onAddContact: (Str
                                 if (number.value.isBlank() || description.value.isBlank()) {
                                     errorState.value = "전화번호나 설명을 입력해주세요."
                                 } else {
-                                    onAddContact(number.value, description.value)
+                                    onAddContact(number.value, description.value, false)
                                     isDialogOpen.value = false
                                     errorState.value = ""
                                 }

--- a/app/src/main/java/com/example/emergencyguide/EmergencyNumber/composables/EmergencyContact.kt
+++ b/app/src/main/java/com/example/emergencyguide/EmergencyNumber/composables/EmergencyContact.kt
@@ -1,0 +1,54 @@
+package com.example.emergencyguide.EmergencyNumber.composables
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.material.Divider
+import androidx.compose.material.Icon
+import androidx.compose.material.IconButton
+import androidx.compose.material.MaterialTheme
+import androidx.compose.material.Text
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Call
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+
+@Composable
+fun EmergencyContact(icon: androidx.compose.ui.graphics.vector.ImageVector, number: String, title: String) {
+    Box(
+        modifier = Modifier
+            .fillMaxWidth()
+            .height(100.dp)
+            .padding(vertical = 8.dp),
+    ) {
+        Row(
+            modifier = Modifier
+                .fillMaxSize(),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Icon(imageVector = icon, contentDescription = title, modifier = Modifier.size(24.dp))
+            Spacer(modifier = Modifier.width(16.dp))
+            Column(
+                modifier = Modifier.weight(1f)
+            ) {
+                Text(text = number, style = MaterialTheme.typography.h6, fontWeight = FontWeight.Bold)
+                Text(text = title)
+            }
+            IconButton(onClick = { /* call action 적기 */ }) {
+                Icon(imageVector = Icons.Default.Call, contentDescription = "Call")
+            }
+        }
+        Divider(color = Color.Gray, thickness = 1.dp, modifier = Modifier.align(Alignment.BottomCenter))
+    }
+}

--- a/app/src/main/java/com/example/emergencyguide/EmergencyNumber/composables/EmergencyContact.kt
+++ b/app/src/main/java/com/example/emergencyguide/EmergencyNumber/composables/EmergencyContact.kt
@@ -10,6 +10,7 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
+import androidx.compose.material.Checkbox
 import androidx.compose.material.Divider
 import androidx.compose.material.Icon
 import androidx.compose.material.IconButton
@@ -18,6 +19,9 @@ import androidx.compose.material.Text
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Call
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.MutableState
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
@@ -25,7 +29,14 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 
 @Composable
-fun EmergencyContact(icon: androidx.compose.ui.graphics.vector.ImageVector, number: String, title: String) {
+fun EmergencyContact(icon: androidx.compose.ui.graphics.vector.ImageVector,
+                     number: String,
+                     title: String,
+                     isEditing: MutableState<Boolean>,
+                     ) {
+
+    val isSelected = remember { mutableStateOf(false) }
+
     Box(
         modifier = Modifier
             .fillMaxWidth()
@@ -45,8 +56,15 @@ fun EmergencyContact(icon: androidx.compose.ui.graphics.vector.ImageVector, numb
                 Text(text = number, style = MaterialTheme.typography.h6, fontWeight = FontWeight.Bold)
                 Text(text = title)
             }
-            IconButton(onClick = { /* call action 적기 */ }) {
-                Icon(imageVector = Icons.Default.Call, contentDescription = "Call")
+            if (isEditing.value) {
+                Checkbox(
+                    checked = isSelected.value,
+                    onCheckedChange = { newValue -> isSelected.value = newValue }
+                )
+            } else {
+                IconButton(onClick = { /* call action 적기 */ }) {
+                    Icon(imageVector = Icons.Default.Call, contentDescription = "Call")
+                }
             }
         }
         Divider(color = Color.Gray, thickness = 1.dp, modifier = Modifier.align(Alignment.BottomCenter))


### PR DESCRIPTION
# 추가된 점
1. '긴급', '비긴급' -> '국가' , '개인' 으로 변경 
2. '개인'에서 추가 버튼, 삭제 버튼 추가 -> AddandDelete 컴포저블 생성
![image](https://github.com/imtaejugkim/EmergencyGuide/assets/77558413/28766a9b-bc06-4477-b3b5-8e7bf3080d91)

3. 플러스 버튼 클릭 시 팝업 등장 -> 전화번호, 설명 입력
![image](https://github.com/imtaejugkim/EmergencyGuide/assets/77558413/e4fa4f14-a750-4bd0-a8af-5c79a02374e4)
- 전화번호에서는 숫자만 입력 가능 (키보드액션 설정으로 전화번호->설명으로 포커스 넘어갈 수 있게 설정)
- 전화번호나 설명이 빈 칸일 시 빨간 글씨로 '전화번호나 설명을 입력해주세요' 문구 출력
![image](https://github.com/imtaejugkim/EmergencyGuide/assets/77558413/13333e79-b831-44b8-b103-5676c2f21965)


4. 삭제 버튼 클릭 시 통화 아이콘 -> 체크박스로 변경
![image](https://github.com/imtaejugkim/EmergencyGuide/assets/77558413/2d02c1ac-a0e4-4a3e-aeb1-9f0059e7caff)

편집 중일 때는 플러스 버튼은 사라진다.
![image](https://github.com/imtaejugkim/EmergencyGuide/assets/77558413/437cea08-4b27-490d-9711-1fd14ea11109)

<br><br>
# 문제점 : 삭제가 구현되지 않는다.
이론상으로는 분명히 삭제가 되어야하는데, 삭제가 되지 않는다.. 계속 시도해보다가 오늘은 그만하기로.
다음에 고쳐볼게요!


