### PR TITLE
Feat: apply delete number and call with phone

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -54,6 +54,7 @@ dependencies {
     implementation("org.jsoup:jsoup:1.14.3")
     implementation(libs.androidx.material.icons.extended)
     implementation(libs.androidx.material3.android)
+    implementation(libs.accompanist.permissions)
     testImplementation(libs.junit)
     androidTestImplementation(libs.androidx.junit)
     androidTestImplementation(libs.androidx.espresso.core)

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools" >
-
+    <uses-permission android:name="android.permission.CALL_PHONE" />
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION"/>
     <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION"/>
-
+    <uses-feature android:name="android.hardware.telephony" />
     <application
         android:allowBackup="true"
         android:dataExtractionRules="@xml/data_extraction_rules"

--- a/app/src/main/java/com/example/emergencyguide/EmergencyNumber/EmergencyNumberActivity.kt
+++ b/app/src/main/java/com/example/emergencyguide/EmergencyNumber/EmergencyNumberActivity.kt
@@ -1,5 +1,6 @@
 package com.example.emergencyguide.EmergencyNumber
 
+import android.content.Context
 import android.graphics.drawable.Icon
 import android.os.Bundle
 import androidx.appcompat.app.AppCompatActivity
@@ -57,14 +58,63 @@ import androidx.compose.ui.unit.dp
 import com.example.emergencyguide.EmergencyNumber.composables.AddandDeleteButtons
 import com.example.emergencyguide.EmergencyNumber.composables.CreatePersonalDialog
 import com.example.emergencyguide.EmergencyNumber.composables.EmergencyContact
+import java.io.BufferedReader
+import java.io.File
+import java.io.InputStreamReader
+import java.io.OutputStreamWriter
 
 class EmergencyNumberActivity : AppCompatActivity() {
     private lateinit var binding: ActivityEmergencyNumberBinding
     private val tabsList = listOf("국가", "개인")
 
+    // 연락처
+    private val contacts = mutableStateListOf<Triple<String, String, MutableState<Boolean>>>()
+
+    // 파일에 작성하는 함수
+    private fun writeToFile(context: Context, data: List<String>) {
+        try {
+            val outputStreamWriter = OutputStreamWriter(context.openFileOutput("contacts.txt", MODE_PRIVATE))
+            outputStreamWriter.write(data.joinToString("\n"))
+            outputStreamWriter.close()
+        } catch (e: Exception) {
+            e.printStackTrace()
+        }
+    }
+
+    private fun readFromFile(): List<String> {
+        val file = File(filesDir, "contacts.txt")
+        if (!file.exists()) {
+            return emptyList()
+        }
+
+        val inputStream = openFileInput("contacts.txt")
+        val reader = BufferedReader(InputStreamReader(inputStream))
+        val contacts = mutableListOf<String>()
+        var line = reader.readLine()
+
+        while (line != null) {
+            contacts.add(line)
+            line = reader.readLine()
+        }
+
+        inputStream.close()
+        return contacts
+    }
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         binding = ActivityEmergencyNumberBinding.inflate(layoutInflater)
+
+        // 텍스트 파일에서 연락처 불러오기
+        val contactData = readFromFile()
+        contactData.forEach { data ->
+            val parts = data.split(",")
+            if (parts.size >= 2) {
+                val number = parts[0]
+                val description = parts[1]
+                contacts.add(Triple(number, description, mutableStateOf(false)))
+            }
+        }
 
         val composeView = binding.composeViewEmergencyNumber
         composeView.setContent {
@@ -83,83 +133,80 @@ class EmergencyNumberActivity : AppCompatActivity() {
         // 수정 중인지 여부
         val isEditing = remember { mutableStateOf(false) }
 
-
-        // 연락처
-        val contacts = remember { mutableStateListOf<Triple<String, String, Boolean>>() }
-
-
-
-        // isSelected가 true인 연락처들을 contacts에서 제거하는 함수
-        fun handleDeleteCompleteClick() {
-            contacts.removeAll { it.third }
-            isEditing.value = false
-        }
-
-
         CreatePersonalDialog(isDialogOpen) { number, description, isSelected ->
-            contacts.add(Triple(number, description, isSelected))
+            contacts.add(Triple(number, description, mutableStateOf(false)))
+            writeToFile(this@EmergencyNumberActivity, contacts.map { "${it.first},${it.second}" })
         }
 
-
-            Surface(
-                modifier = Modifier.fillMaxSize(),
-                color = Color.White
+        Surface(
+            modifier = Modifier.fillMaxSize(),
+            color = Color.White
+        ) {
+            Column(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .padding(16.dp),
             ) {
-                Column(
-                    modifier = Modifier
-                        .fillMaxSize()
-                        .padding(16.dp),
-                ) {
-                    TopAppBar(
-                        title = { Text(text = "긴급 연락처") },
-                        navigationIcon = {
-                            IconButton(onClick = { finish() }) {
-                                Icon(imageVector = Icons.Default.ArrowBack, contentDescription = "Back")
-                            }
-                        },
-                        backgroundColor = Color.White,
-                        contentColor = Color.Black,
-                        elevation = 0.dp
-                    )
+                TopAppBar(
+                    title = { Text(text = "긴급 연락처") },
+                    navigationIcon = {
+                        IconButton(onClick = { finish() }) {
+                            Icon(imageVector = Icons.Default.ArrowBack, contentDescription = "Back")
+                        }
+                    },
+                    backgroundColor = Color.White,
+                    contentColor = Color.Black,
+                    elevation = 0.dp
+                )
 
-                    Row(Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.Start) { // 왼쪽 정렬
-                        TabRow(
-                            selectedTabIndex = selectedTabIndex.value,
-                            backgroundColor = Color.Transparent, // 배경 투명하게
-                            contentColor = Color.Black // 글자 검은색으로
-                        ) {
-                            tabsList.forEachIndexed { index, title ->
-                                Tab(
-                                    text = { Text(title) },
-                                    selected = selectedTabIndex.value == index,
-                                    onClick = { selectedTabIndex.value = index }
-                                )
-                            }
+                Row(Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.Start) { // 왼쪽 정렬
+                    TabRow(
+                        selectedTabIndex = selectedTabIndex.value,
+                        backgroundColor = Color.Transparent, // 배경 투명하게
+                        contentColor = Color.Black // 글자 검은색으로
+                    ) {
+                        tabsList.forEachIndexed { index, title ->
+                            Tab(
+                                text = { Text(title) },
+                                selected = selectedTabIndex.value == index,
+                                onClick = {
+                                    // isEditing이 false일 때만 selectedTabIndex.value를 변경합니다.
+                                    if (!isEditing.value) {
+                                        selectedTabIndex.value = index
+                                    }
+                                }
+                            )
                         }
                     }
+                }
 
-                    when (selectedTabIndex.value) {
-                        0 -> {
-                            EmergencyContact(Icons.Default.LocalFireDepartment, "119", "화재", isEditing)
-                            EmergencyContact(Icons.Default.LocalHospital, "119", "응급실", isEditing)
-                            EmergencyContact(Icons.Default.LocalPolice, "112", "경찰", isEditing)
-                            EmergencyContact(Icons.Default.Waves, "122", "해양사고", isEditing)
+                when (selectedTabIndex.value) {
+                    0 -> {
+                        val isSelected = remember { mutableStateOf(false) }
+                        EmergencyContact(Icons.Default.LocalFireDepartment, "119", "화재", isEditing, isSelected)
+                        EmergencyContact(Icons.Default.LocalHospital, "119", "응급실", isEditing, isSelected)
+                        EmergencyContact(Icons.Default.LocalPolice, "112", "경찰", isEditing, isSelected)
+                        EmergencyContact(Icons.Default.Waves, "122", "해양사고", isEditing, isSelected)
+                    }
+                    1 -> {
+
+                        AddandDeleteButtons(
+                            onAddClick = { isDialogOpen.value = true },
+                            onDeleteClick = { isEditing.value = true },
+                            onDeleteCompleteClick = {
+                                contacts.removeAll { it.third.value }
+                                writeToFile(this@EmergencyNumberActivity, contacts.map { "${it.first},${it.second}" })
+                                isEditing.value = false
+                            },
+                            isEditing = isEditing
+                        )
+                        contacts.forEach { (number, description, isSelected) ->
+                            EmergencyContact(Icons.Default.AccountBox, number, description, isEditing, isSelected)
                         }
-                        1 -> {
 
-                            AddandDeleteButtons(
-                                onAddClick = { isDialogOpen.value = true },
-                                onDeleteClick = { isEditing.value = true },
-                                onDeleteCompleteClick = { handleDeleteCompleteClick() },
-                                isEditing = isEditing
-                            )
-                            contacts.forEach { (number, description) ->
-                                EmergencyContact(Icons.Default.AccountBox, number, description, isEditing)
-                            }
-
-                        }
                     }
                 }
             }
         }
+    }
 }

--- a/app/src/main/java/com/example/emergencyguide/EmergencyNumber/composables/EmergencyContact.kt
+++ b/app/src/main/java/com/example/emergencyguide/EmergencyNumber/composables/EmergencyContact.kt
@@ -1,5 +1,8 @@
 package com.example.emergencyguide.EmergencyNumber.composables
 
+import android.content.Context
+import android.content.Intent
+import android.net.Uri
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -25,17 +28,25 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
+import com.google.accompanist.permissions.ExperimentalPermissionsApi
+import com.google.accompanist.permissions.isGranted
+import com.google.accompanist.permissions.rememberPermissionState
 
+@OptIn(ExperimentalPermissionsApi::class)
 @Composable
 fun EmergencyContact(icon: androidx.compose.ui.graphics.vector.ImageVector,
                      number: String,
                      title: String,
                      isEditing: MutableState<Boolean>,
-                     ) {
+                     isSelected: MutableState<Boolean> // isSelected 상태를 인자로 추가
+)  {
 
-    val isSelected = remember { mutableStateOf(false) }
+    val context = LocalContext.current // 현재 Context를 가져옵니다.
+    val permissionState = rememberPermissionState(permission = android.Manifest.permission.CALL_PHONE)
+
 
     Box(
         modifier = Modifier
@@ -62,7 +73,18 @@ fun EmergencyContact(icon: androidx.compose.ui.graphics.vector.ImageVector,
                     onCheckedChange = { newValue -> isSelected.value = newValue }
                 )
             } else {
-                IconButton(onClick = { /* call action 적기 */ }) {
+                IconButton(onClick = { // 전화 앱을 시작합니다.
+
+                    if(permissionState.status.isGranted){
+                        val number = Uri.parse("tel:$number")
+                        val callIntent = Intent(Intent.ACTION_CALL, number)
+                        context.startActivity(callIntent)
+                    }
+
+                    else
+                        permissionState.launchPermissionRequest()
+
+                     }) {
                     Icon(imageVector = Icons.Default.Call, contentDescription = "Call")
                 }
             }
@@ -70,3 +92,4 @@ fun EmergencyContact(icon: androidx.compose.ui.graphics.vector.ImageVector,
         Divider(color = Color.Gray, thickness = 1.dp, modifier = Modifier.align(Alignment.BottomCenter))
     }
 }
+

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -14,6 +14,7 @@ google-maps-secrets-plugin = "2.0.1"
 google-maps-services = "17.0.0"
 materialIconsExtended = "1.7.0-beta01"
 material3Android = "1.2.1"
+accompanistPermissions = "0.35.1-alpha"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
@@ -33,6 +34,7 @@ google-maps = { group = "com.google.android.gms", name = "play-services-maps", v
 google-locations = { group = "com.google.android.gms", name = "play-services-location", version.ref = "google-maps-services"}
 androidx-material-icons-extended = { group = "androidx.compose.material", name = "material-icons-extended", version.ref = "materialIconsExtended" }
 androidx-material3-android = { group = "androidx.compose.material3", name = "material3-android", version.ref = "material3Android" }
+accompanist-permissions = { group = "com.google.accompanist", name = "accompanist-permissions", version.ref = "accompanistPermissions" }
 
 [plugins]
 androidApplication = { id = "com.android.application", version.ref = "agp" }


### PR DESCRIPTION
1. 번호는 이제 안드로이드 내의 txt 파일에 저장됩니다. github로 txt 파일까지 올라가지는 않으므로 pull 받으시고 새로 번호들 추가하면됩니다. 이제 txt 파일을 읽으면서 개인 연락처가 업데이트 되기 때문에 앱을 나갔다와도 연락처가 삭제되지 않습니다.

2. 연락처 삭제를 구현했습니다.

3. 통화 버튼 클릭 시 통화가 되게 구현했습니다. 일단 기기에 통화 권한이 없다면, 권한 요청을 하는 팝업이 먼저 생성됩니다. 그리고 거기서 동의를 누르고 다시 통화버튼을 누르면 이제 통화가 가능합니다.

 