### PR TITLE
Design: Adjust design in EmergencyNumberActivity and EmergencyGuideActivity to fit with other pages

### DIFF
--- a/app/src/main/java/com/example/emergencyguide/EmergencyGuide/EmergencyGuideActivity.kt
+++ b/app/src/main/java/com/example/emergencyguide/EmergencyGuide/EmergencyGuideActivity.kt
@@ -46,6 +46,7 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.example.emergencyguide.R
 import com.example.emergencyguide.databinding.ActivityEmergencyGuideBinding
+import com.example.emergencyguide.ui.theme.pretendardTypography
 
 class EmergencyGuideActivity : AppCompatActivity() {
     private lateinit var binding: ActivityEmergencyGuideBinding
@@ -55,7 +56,12 @@ class EmergencyGuideActivity : AppCompatActivity() {
 
         val composeView = binding.composeViewEmergencyGuide
         composeView.setContent {
-            InitComposeContent()
+            MaterialTheme(
+                typography = pretendardTypography, // 여기에 Typography를 설정
+                content = {
+                    InitComposeContent()
+                }
+            )
         }
         setContentView(binding.root)
     }
@@ -70,22 +76,26 @@ class EmergencyGuideActivity : AppCompatActivity() {
             modifier = Modifier.fillMaxSize(),
             color = Color.White
         ) {
+            Spacer(modifier = Modifier.height(30.dp))
+
             Column(
                 modifier = Modifier
                     .fillMaxSize()
-                    .padding(16.dp),
+                    .padding(14.dp),
             ) {
-                TopAppBar(
-                    title = { Text(text = "응급 처치") },
-                    navigationIcon = {
-                        IconButton(onClick = { finish() }) {
-                            Icon(imageVector = Icons.Default.ArrowBack, contentDescription = "Back")
-                        }
-                    },
-                    backgroundColor = Color.White,
-                    contentColor = Color.Black,
-                    elevation = 0.dp
-                )
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    verticalAlignment = Alignment.CenterVertically // 아이콘과 제목의 높이를 맞춤
+                ) {
+                    IconButton(onClick = { finish() }) {
+                        Icon(imageVector = Icons.Default.ArrowBack, contentDescription = "Back")
+                    }
+
+                    Spacer(modifier = Modifier.width(100.dp))
+
+                    Text(text = "긴급 연락처", style = pretendardTypography.h1)
+
+                }
 
                 Row(
                     modifier = Modifier

--- a/app/src/main/java/com/example/emergencyguide/EmergencyGuide/EmergencyGuideActivity.kt
+++ b/app/src/main/java/com/example/emergencyguide/EmergencyGuide/EmergencyGuideActivity.kt
@@ -93,7 +93,7 @@ class EmergencyGuideActivity : AppCompatActivity() {
 
                     Spacer(modifier = Modifier.width(100.dp))
 
-                    Text(text = "긴급 연락처", style = pretendardTypography.h1)
+                    Text(text = "응급 처치", style = pretendardTypography.h1)
 
                 }
 

--- a/app/src/main/java/com/example/emergencyguide/EmergencyNumber/EmergencyNumberActivity.kt
+++ b/app/src/main/java/com/example/emergencyguide/EmergencyNumber/EmergencyNumberActivity.kt
@@ -58,6 +58,7 @@ import androidx.compose.ui.unit.dp
 import com.example.emergencyguide.EmergencyNumber.composables.AddandDeleteButtons
 import com.example.emergencyguide.EmergencyNumber.composables.CreatePersonalDialog
 import com.example.emergencyguide.EmergencyNumber.composables.EmergencyContact
+import com.example.emergencyguide.ui.theme.pretendardTypography
 import java.io.BufferedReader
 import java.io.File
 import java.io.InputStreamReader
@@ -118,7 +119,12 @@ class EmergencyNumberActivity : AppCompatActivity() {
 
         val composeView = binding.composeViewEmergencyNumber
         composeView.setContent {
-            InitComposeContent()
+            MaterialTheme(
+                typography = pretendardTypography, // 여기에 Typography를 설정
+                content = {
+                    InitComposeContent()
+                }
+            )
         }
 
         setContentView(binding.root)
@@ -142,22 +148,30 @@ class EmergencyNumberActivity : AppCompatActivity() {
             modifier = Modifier.fillMaxSize(),
             color = Color.White
         ) {
+
+            Spacer(modifier = Modifier.height(30.dp))
+
+
             Column(
                 modifier = Modifier
                     .fillMaxSize()
-                    .padding(16.dp),
+                    .padding(14.dp),
             ) {
-                TopAppBar(
-                    title = { Text(text = "긴급 연락처") },
-                    navigationIcon = {
-                        IconButton(onClick = { finish() }) {
-                            Icon(imageVector = Icons.Default.ArrowBack, contentDescription = "Back")
-                        }
-                    },
-                    backgroundColor = Color.White,
-                    contentColor = Color.Black,
-                    elevation = 0.dp
-                )
+
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    verticalAlignment = Alignment.CenterVertically // 아이콘과 제목의 높이를 맞춤
+                ) {
+                    IconButton(onClick = { finish() }) {
+                        Icon(imageVector = Icons.Default.ArrowBack, contentDescription = "Back")
+                    }
+
+                    Spacer(modifier = Modifier.width(100.dp))
+
+                    Text(text = "긴급 연락처", style = pretendardTypography.h1)
+
+                }
+
 
                 Row(Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.Start) { // 왼쪽 정렬
                     TabRow(

--- a/app/src/main/java/com/example/emergencyguide/ui/theme/Type.kt
+++ b/app/src/main/java/com/example/emergencyguide/ui/theme/Type.kt
@@ -1,0 +1,50 @@
+package com.example.emergencyguide.ui.theme
+
+import androidx.compose.material3.Typography
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.font.Font
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.sp
+import com.example.emergencyguide.R
+
+val pretendardFamily = FontFamily(
+    Font(R.font.pretendard_black, FontWeight.Black),
+    Font(R.font.pretendard_bold, FontWeight.Bold),
+    Font(R.font.pretendard_extrabold, FontWeight.ExtraBold),
+    Font(R.font.pretendard_extralight, FontWeight.ExtraLight),
+    Font(R.font.pretendard_light, FontWeight.Light),
+    Font(R.font.pretendard_medium, FontWeight.Medium),
+    Font(R.font.pretendard_regular, FontWeight.Normal),
+    Font(R.font.pretendard_semibold, FontWeight.SemiBold),
+    Font(R.font.pretendard_thin, FontWeight.Thin),
+)
+
+//// Set of Material typography styles to start with
+//val pretendardTypography = Typography(
+//    bodyLarge = TextStyle(
+////        fontFamily = FontFamily.Default,
+//        fontFamily = pretendardFamily,
+//        fontWeight = FontWeight.Normal,
+//        fontSize = 16.sp,
+//        lineHeight = 24.sp,
+//        letterSpacing = 0.5.sp
+//    )
+//)
+
+// Jetpack Compose의 Material 3는 Material 2와는 다른 API를 사용하므로, 두 버전 간에는 호환성이 없기 때문
+// bodyLarge -> body1으로 수정
+val pretendardTypography = androidx.compose.material.Typography(
+    body1 = TextStyle(
+        fontFamily = pretendardFamily,
+        fontWeight = FontWeight.Normal,
+        fontSize = 16.sp
+    ),
+    
+    // 제목
+    h1 = TextStyle(
+        fontFamily = pretendardFamily,
+        fontWeight = FontWeight.SemiBold,
+        fontSize = 20.sp
+    ),
+)


### PR DESCRIPTION

1. compose가 적용된 page에 pretendard를 적용했습니다.
- 그러기 위해 ui.theme/Type.kt를 생성해서 관련 내용을 작성했습니다.

2. EmergencyGuideActivity와 EmergencyNumberActivity의 디자인을 수정했습니다.
- 맨 위에 30.dp width의 spacer를 생성했습니다.
- 제목의 위치를 조정하고, pretendard semibold, 20.sp로 속성을 바꿨습니다.
- Column의 padding을 14.dp로 바꿨습니다.

### EmergencyGuideActivity 캡처 화면
![image](https://github.com/imtaejugkim/EmergencyGuide/assets/77558413/f305eb0d-9419-4e61-a0d4-49e699979613)

### EmergencyNumberActivity 캡처 화면
![image](https://github.com/imtaejugkim/EmergencyGuide/assets/77558413/aefd4a33-dffa-4d8f-9713-4e8a6312c482)

